### PR TITLE
Fix XCode build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "HTMLKit-Vapor-Provider",
+    platforms: [
+       .macOS(.v10_14)
+    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(


### PR DESCRIPTION
Fix the the build when using the XCode 11 SPM.

Without specifying the minimum deployment target, the XC build in SPM can not build the project because Vapor has a higher minimum deployment target.