### PR TITLE
Updated minimum macOS version for Vapor 4.0.0-beta4 and later

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "HTMLKit-Vapor-Provider",
     platforms: [
-      .macOS(.v10_14),
+      .macOS(.v10_15),
     ],
 
     products: [
@@ -19,7 +19,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/vapor-community/HTMLKit.git", from: "2.0.0-beta.3"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0-beta.3"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0-beta.4"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
in this commit https://github.com/vapor/vapor/commit/c911da17e52788fcd3e0b8494c11e99c7afdfb78 , vapor's minimum macOS version is updated to 10.15.