### PR TITLE
docs(README): add explicit package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you are using Vapor 3, check [this](https://github.com/MatsMoll/htmlkit-vapor
 
 Add this as a dependencies in your `Package.swift` file.
 ```swift
-.package(url: "https://github.com/MatsMoll/htmlkit-vapor-provider.git", from: "1.0.0-beta.4")
+.package(name: "HTMLKitVaporProvider", url: "https://github.com/MatsMoll/htmlkit-vapor-provider.git", from: "1.0.0-beta.4")
 ...
 // And remember to add HTMLKitVaporProvider to your target
 .target(
@@ -21,6 +21,7 @@ Add this as a dependencies in your `Package.swift` file.
 
 This will expose a `htmlkit` variable on `Request` and `Application` as shown below.
 ```swift
+// You can preload Template in your configure method in configure.swift to optimize rendering
 app.htmlkit.add(view: UserTemplate())
 ...
 try req.htmlkit.render(UserTemplate.self, with: user) // Returns a `Response`


### PR DESCRIPTION
* Add explicitly the name of the package in `.package(...)`, for some reasons, it blocked me to integrate the library.
* Explain why and where to put `app.htmlkit.add(view: UserTemplate())` as if you don't know how the library works, it's difficult to guess why it's important to call this before `render` at some point.